### PR TITLE
fix: prefersColorScheme for media theme.

### DIFF
--- a/apps/website/pages/docs/guide/customization.mdx
+++ b/apps/website/pages/docs/guide/customization.mdx
@@ -44,7 +44,7 @@ The `themes` array property accept such object value:
 - `name` name of this theme, which will be used in root element attribute `data-theme` for switching between themes.
 - `colorScheme` actual color scheme of this theme, `light` or `dark`, decide what built-in theme will be merged to it.
 - `colors` color names of this theme, choose your own (default built-in colors merged), sira will generate `50-1100` palette for this color name, and className for styling.
-- `prefersColorScheme` boolean property, set a preference theme in specified `colorScheme`, will enable the preference theme in such media query `@media (prefers-color-scheme:${theme.colorScheme || "light"})`.
+- `prefersColorScheme` boolean property, set a preference theme in specified `colorScheme`, will enable the preference theme in such media query `@media (prefers-color-scheme:${theme.colorScheme || "light"})`. (only work for one theme, multiple themes enable this property will only work for the last theme.)
 
 ```js {6-12}
 module.exports = {

--- a/packages/tailwind/src/config/utils/theme.ts
+++ b/packages/tailwind/src/config/utils/theme.ts
@@ -71,7 +71,7 @@ export const createTheme = (themeObj: Theme) => {
             colorScheme: theme.colorScheme || 'light',
             ...theme.colors,
           },
-          ...themeColorNameClasses,
+          ...colorNameClasses,
         },
       }),
     },


### PR DESCRIPTION
previous version use wrong 'themeColorNameClasses' variable to generate color name classes need 'data-theme' to work well.